### PR TITLE
Resolve warning log

### DIFF
--- a/lib/resty/cookie.lua
+++ b/lib/resty/cookie.lua
@@ -143,7 +143,8 @@ function _M.get_all_for(self, key)
         return nil, "no cookie found in the current request"
     end
     if self.multiple_value_cookie_table == nil then
-        _, self.multiple_value_cookie_table = get_cookie_table(self._cookie)
+        local _, multiple_value_cookie_table = get_cookie_table(self._cookie)
+        self.multiple_value_cookie_table = multiple_value_cookie_table
     end
 
     return self.multiple_value_cookie_table[key]


### PR DESCRIPTION
This PR resolves the warning logs about using a global Lua variable. Now, local variable is used 

Example warn log:
```
2025/05/20 08:17:11 [warn] 1322#0: *6192 [lua] _G write guard:12: __newindex(): writing a global Lua variable ('_') which may lead to race conditions between concurrent requests, so prefer the use of 'local' variables
stack traceback:
	/lua_modules/share/lua/5.1/resty/cookie.lua:146: in function 'get_all_for'
	...es/share/lua/5.1/kong/plugins/authn-passport/handler.lua:76: in function 'get_cookie_token'
```